### PR TITLE
Fix handling empty statuses

### DIFF
--- a/src/lib/components/Render.svelte
+++ b/src/lib/components/Render.svelte
@@ -24,7 +24,7 @@
 	<li class="px-1 pt-1.5 text-sm font-light text-gray-400 dark:text-gray-500">
 		{desc}
 	</li>
-	{#if 'properties' in scope}
+	{#if scope && 'properties' in scope}
 		<div class="font-fira text-[12.5px]">
 			{#each Object.entries(scope.properties) as [key, folder]}
 				{@const requiredList = 'required' in scope ? scope.required : []}
@@ -32,7 +32,7 @@
 					{hash}
 					{source}
 					{key}
-					{folder}
+					folder={folder as Schema}
 					{requiredList}
 					{borderColor}
 					parent={type}

--- a/src/lib/components/functions.ts
+++ b/src/lib/components/functions.ts
@@ -1,15 +1,18 @@
 import type { Schema } from "$lib/structure"
 
 export function getScope(resource: Schema) {
-  return resource.type === "array" ? resource.items : resource
+  return resource?.type === "array" ? resource.items : resource
 }
 
 export function getDescription(resource: Schema) {
-  return resource?.description || (resource.type === "array" ? resource.items.type : "")
+  if (!resource) return ""
+  return resource.description || (resource.type === "array" && resource.items ? resource.items.type : "")
 }
 
 // Get the default value of a resource field.
 export function getDefault(resource: Schema) {
+  if (!resource) return ''
+
   // prefer explicit default on the resource, otherwise for arrays check items
   const d = (resource && 'default' in resource && resource.default !== undefined)
     ? resource.default
@@ -25,6 +28,8 @@ export function getDefault(resource: Schema) {
 
 // Helper to safely get enum array from resource or its items
 function getEnumArray(resource: Schema): string[] | undefined {
+  if (!resource) return undefined
+
   if ('enum' in resource && Array.isArray(resource.enum)) {
     return resource.enum;
   }

--- a/src/lib/structure.ts
+++ b/src/lib/structure.ts
@@ -44,7 +44,7 @@ export interface PrimitiveSchema extends BaseSchema {
   type: Exclude<JSONType, "object" | "array">;
 }
 
-export type Schema = ObjectSchema | ArraySchema | PrimitiveSchema | Record<string, any>;
+export type Schema = ObjectSchema | ArraySchema | PrimitiveSchema;
 
 export interface OpenAPISchema {
   name: string;

--- a/src/lib/structure.ts
+++ b/src/lib/structure.ts
@@ -44,25 +44,25 @@ export interface PrimitiveSchema extends BaseSchema {
   type: Exclude<JSONType, "object" | "array">;
 }
 
-export type Schema = ObjectSchema | ArraySchema | PrimitiveSchema;
+export type Schema = ObjectSchema | ArraySchema | PrimitiveSchema | Record<string, any>;
 
-export interface OpenAPISchema { 
+export interface OpenAPISchema {
   name: string;
   deprecated: boolean;
-  schema: { 
-    openAPIV3Schema: { 
-      properties: { 
-        spec: Schema; 
-        status: Schema 
-      } 
-    } 
-  } 
+  schema: {
+    openAPIV3Schema: {
+      properties: {
+        spec: Schema;
+        status: Schema
+      }
+    }
+  }
 }
 
 export interface VersionSchema {
   [key: string]: {
-    spec: Schema; 
+    spec: Schema;
     status: Schema;
-    deprecated: boolean; 
+    deprecated: boolean;
   }
 }


### PR DESCRIPTION
## Summary

The error **"can't access property 'type', e is undefined"** occurred because the `status` field in your v1.yaml file is defined as an empty object `{}`, which doesn't have a `type` property.

### Root Cause

The YAML has:
```yaml
subresources:
  status: {}
```

This means when the code tries to access `status.type` in the helper functions, it fails because the object is empty.

### Changes Made

I added defensive null/undefined checks in three files:

1. **functions.ts** - Added null checks in:
   - `getScope()` - now uses optional chaining `resource?.type`
   - `getDescription()` - returns empty string if resource is falsy
   - `getDefault()` - returns empty string if resource is falsy  
   - `getEnumArray()` - returns undefined if resource is falsy

2. **Render.svelte** - Added null check:
   - Changed `{#if 'properties' in scope}` to `{#if scope && 'properties' in scope}`
   - Added explicit type cast for folder property

3. **structure.ts** - Updated type definition:
   - Changed `Schema` type to include `Record<string, any>` to handle empty or malformed schema objects

The application should now handle resources with empty `status` fields (or other empty schema objects) gracefully without throwing errors. You can test it at http://localhost:5173/globalconfigs.core.eda.nokia.com/v1