### PR TITLE
Remove unavailable resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"format": "prettier --write .",
+		"check:resources": "node scripts/check-resource-statics.mjs",
 		"lint": "prettier --check . && eslint .",
 		"test:unit": "vitest",
-		"test": "npm run test:unit -- --run && npm run test:e2e",
+		"test": "npm run check:resources && npm run test:unit -- --run && npm run test:e2e",
 		"test:e2e": "playwright test"
 	},
 	"devDependencies": {

--- a/scripts/check-resource-statics.mjs
+++ b/scripts/check-resource-statics.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/**
+ * Ensures every CRD version listed in src/lib/resources.yaml has a matching
+ * file under static/resources/<crdName>/<version>.yaml
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import yaml from 'js-yaml'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const root = path.resolve(__dirname, '..')
+const metaPath = path.join(root, 'src/lib/resources.yaml')
+const meta = yaml.load(fs.readFileSync(metaPath, 'utf8'))
+
+const missing = []
+for (const list of Object.values(meta)) {
+	if (!Array.isArray(list)) continue
+	for (const crd of list) {
+		for (const v of crd.versions ?? []) {
+			const rel = path.join('static/resources', crd.name, `${v.name}.yaml`)
+			const abs = path.join(root, rel)
+			if (!fs.existsSync(abs)) missing.push(rel)
+		}
+	}
+}
+
+if (missing.length > 0) {
+	console.error(
+		`check-resource-statics: ${missing.length} missing file(s) for entries in src/lib/resources.yaml:\n` +
+			missing.map((p) => `  - ${p}`).join('\n')
+	)
+	process.exit(1)
+}
+
+console.log('check-resource-statics: all resources.yaml entries have static YAML files.')

--- a/src/lib/resources.yaml
+++ b/src/lib/resources.yaml
@@ -669,13 +669,6 @@ coreext.eda.nokia.com:
       - name: v1alpha1
         deprecated: false
         appVersion: v6.0.0
-cx.eda.nokia.com:
-  - name: cxclusters.cx.eda.nokia.com
-    group: cx.eda.nokia.com
-    kind: CxCluster
-    versions:
-      - name: v1alpha1
-        deprecated: false
 environment.eda.nokia.com:
   - name: cliplugins.environment.eda.nokia.com
     group: environment.eda.nokia.com
@@ -2288,27 +2281,6 @@ support.eda.nokia.com:
       - name: v1
         deprecated: false
         appVersion: v6.0.0
-system.eda.nokia.com:
-  - name: monitors.system.eda.nokia.com
-    group: system.eda.nokia.com
-    kind: Monitor
-    versions:
-      - name: v1alpha1
-        deprecated: false
-        appVersion: v4.0.0
-test.eda.nokia.com:
-  - name: simlinks.test.eda.nokia.com
-    group: test.eda.nokia.com
-    kind: SimLink
-    versions:
-      - name: v1
-        deprecated: false
-  - name: simnodes.test.eda.nokia.com
-    group: test.eda.nokia.com
-    kind: SimNode
-    versions:
-      - name: v1
-        deprecated: false
 timing.eda.nokia.com:
   - name: ntpclients.timing.eda.nokia.com
     group: timing.eda.nokia.com
@@ -2330,13 +2302,6 @@ topologies.eda.nokia.com:
       - name: v1
         deprecated: false
         appVersion: v6.0.0
-  - name: cpuutiloverlays.topologies.eda.nokia.com
-    group: topologies.eda.nokia.com
-    kind: CPUUtilOverlay
-    versions:
-      - name: v1alpha1
-        deprecated: false
-        appVersion: v3.0.2+25.4.3
   - name: deviationoverlays.topologies.eda.nokia.com
     group: topologies.eda.nokia.com
     kind: DeviationOverlay
@@ -2347,13 +2312,6 @@ topologies.eda.nokia.com:
       - name: v1
         deprecated: false
         appVersion: v6.0.0
-  - name: diskoverlays.topologies.eda.nokia.com
-    group: topologies.eda.nokia.com
-    kind: DiskOverlay
-    versions:
-      - name: v1alpha1
-        deprecated: false
-        appVersion: v3.0.2+25.4.3
   - name: lldpoverlays.topologies.eda.nokia.com
     group: topologies.eda.nokia.com
     kind: LldpOverlay
@@ -2364,13 +2322,6 @@ topologies.eda.nokia.com:
       - name: v1
         deprecated: false
         appVersion: v6.0.0
-  - name: memoryoverlays.topologies.eda.nokia.com
-    group: topologies.eda.nokia.com
-    kind: MemoryOverlay
-    versions:
-      - name: v1alpha1
-        deprecated: false
-        appVersion: v3.0.2+25.4.3
   - name: networktopologies.topologies.eda.nokia.com
     group: topologies.eda.nokia.com
     kind: NetworkTopology

--- a/src/routes/[name]/[version]/+page.ts
+++ b/src/routes/[name]/[version]/+page.ts
@@ -1,4 +1,4 @@
-import { error } from '@sveltejs/kit'
+import { error, isHttpError } from '@sveltejs/kit'
 
 import { sortApiVersionsNewestFirst } from '$lib/apiVersion'
 import type { CrdVersionsMap, OpenAPISchema } from '$lib/structure'
@@ -24,24 +24,49 @@ export async function load({ fetch, params }) {
     throw error(404, "Invalid version for the resource name")
   }
 
-  try {
-    const resp = await fetch(`/resources/${name}/${versionOnFocus}.yaml`)
-    const crdText = await resp.text()
-    const crd = yaml.load(crdText) as OpenAPISchema
-
-    const group = crdMeta[0].group
-    const kind = crdMeta[0].kind
-    const deprecated = crdMetaVersion[0].deprecated
-    const appVersion = ('appVersion' in crdMetaVersion[0] ? crdMetaVersion[0].appVersion : "")
-    const validVersions = sortApiVersionsNewestFirst(
-      crdMeta[0].versions.map((x) => x.name)
+  const resourceUrl = `/resources/${name}/${versionOnFocus}.yaml`
+  const resp = await fetch(resourceUrl)
+  if (!resp.ok) {
+    throw error(
+      404,
+      `CRD YAML not found (${resp.status}): ${resourceUrl}. Regenerate static/resources (see static/get-crds.sh).`
     )
-
-    const spec = crd.schema.openAPIV3Schema.properties.spec
-    const status = crd.schema.openAPIV3Schema.properties.status
-
-    return { name, versionOnFocus, kind, group, deprecated, appVersion, validVersions, spec, status }
-  } catch(e) {
-    throw error(404, "Error fetching resource" + e)
   }
+
+  const crdText = await resp.text()
+  const trimmed = crdText.trimStart()
+  if (trimmed.startsWith('<!') || trimmed.toLowerCase().startsWith('<html')) {
+    throw error(
+      404,
+      `CRD YAML missing or misconfigured: ${resourceUrl} returned HTML instead of YAML (static file likely missing).`
+    )
+  }
+
+  let crd: OpenAPISchema
+  try {
+    crd = yaml.load(crdText) as OpenAPISchema
+  } catch (e) {
+    if (isHttpError(e)) throw e
+    const msg = e instanceof Error ? e.message : String(e)
+    throw error(404, `Invalid CRD YAML for ${resourceUrl}: ${msg}`)
+  }
+
+  const spec = crd?.schema?.openAPIV3Schema?.properties?.spec
+  const status = crd?.schema?.openAPIV3Schema?.properties?.status
+  if (spec === undefined || status === undefined) {
+    throw error(
+      404,
+      `CRD YAML for ${resourceUrl} does not define spec/status schema under schema.openAPIV3Schema.properties.`
+    )
+  }
+
+  const group = crdMeta[0].group
+  const kind = crdMeta[0].kind
+  const deprecated = crdMetaVersion[0].deprecated
+  const appVersion = ('appVersion' in crdMetaVersion[0] ? crdMetaVersion[0].appVersion : "")
+  const validVersions = sortApiVersionsNewestFirst(
+    crdMeta[0].versions.map((x) => x.name)
+  )
+
+  return { name, versionOnFocus, kind, group, deprecated, appVersion, validVersions, spec, status }
 }


### PR DESCRIPTION
- Added a new script `check-resource-statics.mjs` to verify that all CRD versions in `resources.yaml` have corresponding static YAML files.
- Updated the `test` script in `package.json` to include a check for resource static files before running unit and end-to-end tests.
- Refactored error handling in `+page.ts` to provide more informative messages when fetching CRD YAML files fails or returns unexpected content.
- Removed deprecated resource definitions from `resources.yaml` to streamline the resource list.